### PR TITLE
fix(LoaderPlugin): not redeclare imports

### DIFF
--- a/src/aurelia-loader-nodejs.ts
+++ b/src/aurelia-loader-nodejs.ts
@@ -1,5 +1,5 @@
 import {Origin} from 'aurelia-metadata';
-import {Loader, TemplateRegistryEntry, LoaderPlugin} from 'aurelia-loader';
+import {Loader, TemplateRegistryEntry} from 'aurelia-loader';
 import {DOM, PLATFORM} from 'aurelia-pal';
 import * as path from 'path';
 import * as fs from 'fs';
@@ -137,7 +137,7 @@ export class NodeJsLoader extends Loader {
       } catch (e) {
         // last try, file is relative, but didn't specify ./ in the path
         if (!path.isAbsolute(modulePath)) {
-          modulePath = path.resolve(Options.relativeToDir, modulePath);
+          modulePath = path.resolve(Options.relativeToDir as string, modulePath);
           return await advancedRequire(modulePath);
         }
         throw firstError;


### PR DESCRIPTION
This pull request would address the issues regarding upgrade to Typescript 3.7: https://github.com/aurelia/loader-nodejs/issues/6

Also, typecasting for module path
![image](https://user-images.githubusercontent.com/14221153/72444291-61d0da00-3775-11ea-8538-f3fa82576635.png)
